### PR TITLE
fix(topology): filter degenerate rings in correct_tree (#64)

### DIFF
--- a/crates/core/src/build_result.rs
+++ b/crates/core/src/build_result.rs
@@ -509,6 +509,24 @@ fn build_polygon<T: CoordNum + Copy>(
         }
     };
 
+    // Fix for issue #64: Skip degenerate exterior rings (< 3 points)
+    // This is defensive - correct_tree should have already cleared these,
+    // but we check here to prevent any edge cases from leaking through.
+    if exterior_ring.points().len() < 3 {
+        // Process children to collect grandchildren even if exterior is degenerate
+        for &child_index in exterior_ring.children() {
+            if let Some(child_ring) = manager.get(child_index) {
+                for &grandchild_index in child_ring.children() {
+                    grandchildren.push(grandchild_index);
+                }
+            }
+        }
+        return (
+            Polygon::new(LineString::new(Vec::new()), Vec::new()),
+            grandchildren,
+        );
+    }
+
     // Convert exterior ring to LineString
     let exterior = ring_to_linestring(exterior_ring, reverse_output);
 
@@ -1189,6 +1207,54 @@ mod tests {
         assert!(
             !manager.top_level_rings().contains(&ring),
             "BUG #57: ring is still in top_level_rings after being assigned to a parent"
+        );
+    }
+
+    // ==================== Issue #64: Degenerate ring filtering tests ====================
+
+    /// Test that build_polygon skips degenerate exterior rings (< 3 points).
+    /// Fix for issue #64: Defensive filtering in build_polygon.
+    #[test]
+    fn build_polygon_skips_degenerate_exterior() {
+        let mut manager: RingManager<f64> = RingManager::new();
+
+        // Create a degenerate ring with only 2 points
+        let mut degenerate: Ring<f64> = Ring::empty();
+        degenerate.push_point(Coord { x: 0.0, y: 0.0 });
+        degenerate.push_point(Coord { x: 10.0, y: 10.0 });
+        let degenerate_idx = manager.add_ring(degenerate);
+
+        // Build polygon from degenerate exterior
+        let (polygon, _grandchildren) = build_polygon(&manager, degenerate_idx, false);
+
+        // Should return empty polygon
+        assert!(
+            polygon.exterior().0.is_empty(),
+            "Degenerate exterior (< 3 points) should produce empty polygon"
+        );
+    }
+
+    /// Test that build_result filters out degenerate exterior rings.
+    #[test]
+    fn build_result_filters_degenerate_rings() {
+        let mut manager: RingManager<f64> = RingManager::new();
+
+        // Add one valid ring
+        manager.add_ring(make_square_ring(10.0));
+
+        // Add one degenerate ring (only 2 points)
+        let mut degenerate: Ring<f64> = Ring::empty();
+        degenerate.push_point(Coord { x: 50.0, y: 50.0 });
+        degenerate.push_point(Coord { x: 60.0, y: 60.0 });
+        manager.add_ring(degenerate);
+
+        let result = build_result(&manager, false);
+
+        // Should only have 1 polygon (the valid one)
+        assert_eq!(
+            result.0.len(),
+            1,
+            "Degenerate rings should be filtered from build_result output"
         );
     }
 }

--- a/crates/core/src/topology_correction.rs
+++ b/crates/core/src/topology_correction.rs
@@ -652,9 +652,53 @@ fn correct_orientations<T: CoordNum + Copy>(manager: &mut crate::build_result::R
 /// 3. A ring becomes a child of the smallest ring that contains it
 ///    and has opposite orientation (exterior contains hole, hole contains exterior)
 fn correct_tree<T: CoordNum + Copy>(manager: &mut crate::build_result::RingManager<T>) {
-    use crate::ring_util::ring_area;
+    use crate::ring_util::{ring_area, value_is_zero};
 
-    // Collect ring data for sorting
+    // PORT FROM: C++ topology_correction.hpp lines 1275-1280
+    // First pass: Remove degenerate rings (< 3 points or zero area)
+    // C++ code:
+    //   if ((*itr)->points == nullptr) { continue; }
+    //   if ((*itr)->size() < 3 || value_is_zero((*itr)->area())) {
+    //       remove_ring_and_points(*itr, manager, false);
+    //       continue;
+    //   }
+    let indices: Vec<usize> = manager.ring_indices().collect();
+    let mut degenerate_indices: Vec<usize> = Vec::new();
+
+    for idx in &indices {
+        if let Some(ring) = manager.get(*idx) {
+            let points = ring.points();
+            if points.is_empty() {
+                // Already cleared, skip
+                continue;
+            }
+            if points.len() < 3 {
+                degenerate_indices.push(*idx);
+                continue;
+            }
+            let area = ring_area(points);
+            if value_is_zero(area) {
+                degenerate_indices.push(*idx);
+            }
+        }
+    }
+
+    // Clear degenerate rings (equivalent to C++ remove_ring_and_points)
+    for idx in degenerate_indices {
+        if crate::debug::debug_enabled() {
+            eprintln!(
+                "[TOPOLOGY] correct_tree: clearing degenerate ring {} (< 3 points or zero area)",
+                idx
+            );
+        }
+        if let Some(ring) = manager.get_mut(idx) {
+            ring.points_mut().clear();
+        }
+        manager.clear_parent(idx);
+        manager.clear_children(idx);
+    }
+
+    // Collect ring data for sorting (only valid rings)
     let mut ring_data: Vec<(usize, f64, BBoxF64, bool)> = Vec::new();
 
     for idx in manager.ring_indices() {
@@ -664,6 +708,10 @@ fn correct_tree<T: CoordNum + Copy>(manager: &mut crate::build_result::RingManag
                 continue;
             }
             let area = ring_area(points);
+            if value_is_zero(area) {
+                // Already cleared above, skip
+                continue;
+            }
             if let Some(bbox) = BBoxF64::from_ring(points) {
                 // Determine hole status from area sign, NOT from stored flag
                 // PORT FROM: C++ ring.hpp is_hole() - negative area = clockwise = hole
@@ -5013,6 +5061,92 @@ mod tests {
         assert!(
             manager.top_level_rings().contains(&hole_idx),
             "Demoted hole should be added to top_level_rings"
+        );
+    }
+
+    // ==================== Issue #64: Degenerate ring filtering tests ====================
+
+    /// PORT FROM: C++ topology_correction.hpp lines 1278-1280
+    /// Test that correct_tree removes rings with < 3 points.
+    ///
+    /// C++ code:
+    /// ```cpp
+    /// if ((*itr)->size() < 3 || value_is_zero((*itr)->area())) {
+    ///     remove_ring_and_points(*itr, manager, false);
+    ///     continue;
+    /// }
+    /// ```
+    #[test]
+    fn test_correct_tree_removes_degenerate_rings_less_than_3_points() {
+        let mut manager: RingManager<f64> = RingManager::new();
+
+        // Create a valid exterior ring (CCW = positive area)
+        let mut valid_ring: Ring<f64> = Ring::empty();
+        valid_ring.push_point(Coord { x: 0.0, y: 0.0 });
+        valid_ring.push_point(Coord { x: 100.0, y: 0.0 });
+        valid_ring.push_point(Coord { x: 100.0, y: 100.0 });
+        valid_ring.push_point(Coord { x: 0.0, y: 100.0 });
+        let valid_idx = manager.add_ring(valid_ring);
+
+        // Create a degenerate ring with only 2 points
+        let mut degenerate_ring: Ring<f64> = Ring::empty();
+        degenerate_ring.push_point(Coord { x: 50.0, y: 50.0 });
+        degenerate_ring.push_point(Coord { x: 60.0, y: 60.0 });
+        let degenerate_idx = manager.add_ring(degenerate_ring);
+
+        // Run correct_tree
+        correct_tree(&mut manager);
+
+        // Valid ring should still have points
+        assert!(
+            manager.get(valid_idx).unwrap().points().len() >= 3,
+            "Valid ring should still have >= 3 points"
+        );
+
+        // Degenerate ring should be cleared (0 points)
+        // PORT FROM: C++ remove_ring_and_points clears the points
+        assert_eq!(
+            manager.get(degenerate_idx).unwrap().points().len(),
+            0,
+            "Degenerate ring (< 3 points) should be cleared by correct_tree"
+        );
+    }
+
+    /// PORT FROM: C++ topology_correction.hpp lines 1278-1280
+    /// Test that correct_tree removes rings with zero area.
+    #[test]
+    fn test_correct_tree_removes_zero_area_rings() {
+        let mut manager: RingManager<f64> = RingManager::new();
+
+        // Create a valid exterior ring
+        let mut valid_ring: Ring<f64> = Ring::empty();
+        valid_ring.push_point(Coord { x: 0.0, y: 0.0 });
+        valid_ring.push_point(Coord { x: 100.0, y: 0.0 });
+        valid_ring.push_point(Coord { x: 100.0, y: 100.0 });
+        valid_ring.push_point(Coord { x: 0.0, y: 100.0 });
+        let valid_idx = manager.add_ring(valid_ring);
+
+        // Create a zero-area ring (collinear points)
+        let mut zero_area_ring: Ring<f64> = Ring::empty();
+        zero_area_ring.push_point(Coord { x: 10.0, y: 10.0 });
+        zero_area_ring.push_point(Coord { x: 20.0, y: 10.0 });
+        zero_area_ring.push_point(Coord { x: 30.0, y: 10.0 }); // All on same line
+        let zero_area_idx = manager.add_ring(zero_area_ring);
+
+        // Run correct_tree
+        correct_tree(&mut manager);
+
+        // Valid ring should still have points
+        assert!(
+            manager.get(valid_idx).unwrap().points().len() >= 3,
+            "Valid ring should still have >= 3 points"
+        );
+
+        // Zero-area ring should be cleared
+        assert_eq!(
+            manager.get(zero_area_idx).unwrap().points().len(),
+            0,
+            "Zero-area ring should be cleared by correct_tree"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #64 - Degenerate rings (0 points, duplicate coords) leak to output.

**Root cause:** C++ removes rings with `< 3 points` OR `zero area` in `correct_tree` using `remove_ring_and_points()`, but Rust only skipped them during hierarchy building - they still existed in the manager and leaked to output.

**Changes:**
- `correct_tree` now clears degenerate rings before building parent/child hierarchy (PORT FROM: C++ topology_correction.hpp lines 1275-1280)
- Added defensive check in `build_polygon` for exterior rings < 3 points
- Added 4 unit tests

## Test Results

| Category | Before | After | Change |
|----------|--------|-------|--------|
| Lib tests | 630 | 634 | +4 (new tests) |
| Golden tests | 57 | 59 | **+2** |

## Test Plan

- [x] Unit tests for `correct_tree` degenerate ring removal
- [x] Unit tests for `build_polygon` defensive filtering
- [x] No regressions in existing lib tests
- [x] Golden tests improved

🤖 Generated with [Claude Code](https://claude.com/claude-code)