### PR TITLE
bump: version 0.2.0 → 0.2.1

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.0"
+version = "0.2.1"
 tag_format = "v$version"
 version_files = [
     "Cargo.toml:^version",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.2.1 (2026-03-10)
+
+### Fix
+
+- **vatti**: handle horizontal edges in create_bound_towards_maximum
+
 ## v0.2.0 (2026-03-09)
 
 ### Feat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Nissim Lebovits <nlebovits@pm.me>"]
@@ -18,7 +18,7 @@ categories = ["science", "algorithms", "mathematics"]
 
 [workspace.dependencies]
 # Internal crates
-wagyu-rs = { path = "crates/core", version = "0.2.0" }
+wagyu-rs = { path = "crates/core", version = "0.2.1" }
 
 # Core geometry
 geo = "0.32"


### PR DESCRIPTION
## Summary

Patch release for issue #106 fix.

### Changes in v0.2.1
- fix(vatti): handle horizontal edges in `create_bound_towards_maximum` (#107)
- Fixes clip operation producing coordinates outside clip box for concave polygons

### Version files updated
- `Cargo.toml` workspace version
- `Cargo.toml` wagyu-rs dependency
- `.cz.toml` commitizen version
- `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.ai/code)